### PR TITLE
Add yamllint configuration for consistent indentation

### DIFF
--- a/.coafile
+++ b/.coafile
@@ -9,7 +9,7 @@ max_lines_per_file = 2000
 bears = YAMLLintBear
 files = **.yaml, **.yml
 ignore = .zuul.yaml
-max_line_length = 120
+yamllint_config = .yamllint
 
 [zuul.yaml]
 bears = YAMLLintBear

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,6 @@
+---
+extends: default
+
+rules:
+  indentation: {spaces: 2, indent-sequences: consistent}
+  line-length: {max: 120}


### PR DESCRIPTION
Add rule to indent sequences in a consistent manner instead of force
indentation.

Example:

the following code snippet would PASS:

```
- flying:
  - spaghetti
  - monster
- not flying:
  - spaghetti
  - sauce
```

so will this:

```
- flying:
    - spaghetti
    - monster
- not flying:
    - spaghetti
    - sauce
```

the following code snippet would FAIL:

```
- flying:
    - spaghetti
    - monster
- not flying:
  - spaghetti
  - sauce
```

Signed-off-by: Marek Cermak <macermak@redhat.com>

modified:   .coafile
new file:   .yamllint