### PR TITLE
consistency in workflow while using secrets

### DIFF
--- a/templates/solver-rhel-8.0-py36.yaml
+++ b/templates/solver-rhel-8.0-py36.yaml
@@ -33,10 +33,10 @@ spec:
               bucket: "thoth"
               insecure: true
               accessKeySecret:
-                name: argo-artifact-repository
+                name: argo-artifact-repository-secrets
                 key: accessKey
               secretKeySecret:
-                name: argo-artifact-repository
+                name: argo-artifact-repository-secrets
                 key: secretKey
       container:
         name: solver


### PR DESCRIPTION
consistency in workflow while using secrets

The workflow-controller on deployment creates secret named: argo-artifact-repository-secrets
https://github.com/thoth-station/ansible-role-argo-workflows/blob/7233110287bb1dc198a446554398929d84e52e09/templates/secrets/secrets.yaml#L4
Feel like secret argo-artifact-repository is redundant.

Signed-off-by: Harshad Reddy Nalla hnalla@redhat.com